### PR TITLE
Move comma in a multiline constraint type list after the constraint type

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/io/github/ktlint/core/ruleset/standard/rules/WrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/io/github/ktlint/core/ruleset/standard/rules/WrappingRule.kt
@@ -33,6 +33,8 @@ import io.github.ktlint.core.rule.engine.core.api.ElementType.SUPER_TYPE_CALL_EN
 import io.github.ktlint.core.rule.engine.core.api.ElementType.SUPER_TYPE_ENTRY
 import io.github.ktlint.core.rule.engine.core.api.ElementType.SUPER_TYPE_LIST
 import io.github.ktlint.core.rule.engine.core.api.ElementType.TYPE_ARGUMENT_LIST
+import io.github.ktlint.core.rule.engine.core.api.ElementType.TYPE_CONSTRAINT
+import io.github.ktlint.core.rule.engine.core.api.ElementType.TYPE_CONSTRAINT_LIST
 import io.github.ktlint.core.rule.engine.core.api.ElementType.TYPE_PARAMETER
 import io.github.ktlint.core.rule.engine.core.api.ElementType.TYPE_PARAMETER_LIST
 import io.github.ktlint.core.rule.engine.core.api.ElementType.TYPE_PROJECTION
@@ -75,6 +77,7 @@ import io.github.ktlint.core.rule.engine.core.api.prevCodeLeaf
 import io.github.ktlint.core.rule.engine.core.api.prevCodeSibling
 import io.github.ktlint.core.rule.engine.core.api.prevLeaf
 import io.github.ktlint.core.rule.engine.core.api.prevSibling
+import io.github.ktlint.core.rule.engine.core.api.remove
 import io.github.ktlint.core.rule.engine.core.api.upsertWhitespaceAfterMe
 import io.github.ktlint.core.rule.engine.core.api.upsertWhitespaceBeforeMe
 import io.github.ktlint.core.ruleset.standard.StandardRule
@@ -133,6 +136,7 @@ public class WrappingRule :
             SUPER_TYPE_LIST -> rearrangeSuperTypeList(node, emit)
             VALUE_PARAMETER_LIST, VALUE_ARGUMENT_LIST -> rearrangeValueList(node, emit)
             TYPE_ARGUMENT_LIST, TYPE_PARAMETER_LIST -> rearrangeTypeArgumentList(node, emit)
+            TYPE_CONSTRAINT_LIST -> rearrangeTypeConstraintList(node, emit)
             ARROW -> rearrangeArrow(node, emit)
             WHITE_SPACE -> line += node.text.count { it == '\n' }
             CLOSING_QUOTE -> rearrangeClosingQuote(node, emit)
@@ -424,6 +428,69 @@ public class WrappingRule :
                             .ifAutocorrectAllowed {
                                 closingAngle.upsertWhitespaceBeforeMe(indentConfig.siblingIndentOf(node))
                             }
+                    }
+                }
+        }
+    }
+
+    private fun rearrangeTypeConstraintList(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> AutocorrectDecision,
+    ) {
+        require(node.elementType == TYPE_CONSTRAINT_LIST)
+
+        if (node.textContains('\n')) {
+            // Each type projection must be preceded with a whitespace containing a newline
+            node
+                .children
+                .forEach { child ->
+                    when (child.elementType) {
+                        COMMA -> {
+                            child
+                                .prevSibling // { !it.isPartOfComment }
+                                ?.takeIf { it.isWhiteSpaceWithNewline }
+                                ?.let { whitespaceWithNewline ->
+                                    emit(child.startOffset, "No whitespace was expected before '${child.text}'", true)
+                                        .ifAutocorrectAllowed {
+                                            if (whitespaceWithNewline.prevLeaf?.elementType == EOL_COMMENT) {
+                                                // In case the comma was preceded by an EOL_COMMENT then move the comma before that comment
+                                                //        where T : CharSequence // Some comment
+                                                //            , T : Comparable<T>
+                                                val eolCommentBeforeComma = whitespaceWithNewline.prevLeaf!!
+                                                val insertCommaBefore =
+                                                    eolCommentBeforeComma
+                                                        .prevLeaf
+                                                        .takeIf { it.isWhiteSpace }
+                                                        ?: eolCommentBeforeComma
+                                                eolCommentBeforeComma.treeParent.addChild(LeafPsiElement(COMMA, ","), insertCommaBefore)
+                                                child
+                                                    .nextSibling
+                                                    ?.takeIf { it.isWhiteSpace }
+                                                    ?.remove()
+                                                child.remove()
+                                            } else {
+                                                whitespaceWithNewline.remove()
+                                            }
+                                        }
+                                }
+                        }
+
+                        TYPE_CONSTRAINT -> {
+                            child
+                                .prevSibling { !it.isPartOfComment }
+                                .let { prevSibling ->
+                                    if (prevSibling.isWhiteSpaceWithoutNewline) {
+                                        emit(child.startOffset, "A newline was expected before '${child.text}'", true)
+                                            .ifAutocorrectAllowed {
+                                                child.upsertWhitespaceBeforeMe(indentConfig.siblingIndentOf(node))
+                                            }
+                                    }
+                                }
+                        }
+
+                        else -> {
+                            // No-op
+                        }
                     }
                 }
         }

--- a/ktlint-ruleset-standard/src/test/kotlin/io/github/ktlint/core/ruleset/standard/rules/SpacingAroundCommaRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/io/github/ktlint/core/ruleset/standard/rules/SpacingAroundCommaRuleTest.kt
@@ -176,4 +176,46 @@ class SpacingAroundCommaRuleTest {
         spacingAroundCommaRuleAssertThat(code)
             .hasNoLintViolations()
     }
+
+    @Test
+    fun `Given a function with return type and WHERE and unexpected space before comma between type constraints `() {
+        val code =
+            """
+            fun <T> copyWhenGreater(list: List<T>, threshold: T): List<String>
+                where T : CharSequence , T : Comparable<T> {
+                return list.filter { it > threshold }.map { it.toString() }
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            fun <T> copyWhenGreater(list: List<T>, threshold: T): List<String>
+                where T : CharSequence, T : Comparable<T> {
+                return list.filter { it > threshold }.map { it.toString() }
+            }
+            """.trimIndent()
+        spacingAroundCommaRuleAssertThat(code)
+            .hasLintViolation(2, 27, "Unexpected spacing before \",\"")
+            .isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a function with return type and WHERE and no space space after comma between type constraints `() {
+        val code =
+            """
+            fun <T> copyWhenGreater(list: List<T>, threshold: T): List<String>
+                where T : CharSequence,T : Comparable<T> {
+                return list.filter { it > threshold }.map { it.toString() }
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            fun <T> copyWhenGreater(list: List<T>, threshold: T): List<String>
+                where T : CharSequence, T : Comparable<T> {
+                return list.filter { it > threshold }.map { it.toString() }
+            }
+            """.trimIndent()
+        spacingAroundCommaRuleAssertThat(code)
+            .hasLintViolation(2, 28, "Missing spacing after \",\"")
+            .isFormattedAs(formattedCode)
+    }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/io/github/ktlint/core/ruleset/standard/rules/WrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/io/github/ktlint/core/ruleset/standard/rules/WrappingRuleTest.kt
@@ -286,8 +286,10 @@ internal class WrappingRuleTest {
                 val adapter1: A1,
                 val adapter2: A2
             ) : RecyclerView.Adapter<C>()
-                where A1 : RecyclerView.Adapter<V1>, A1 : ComposableAdapter.ViewTypeProvider,
-                      A2 : RecyclerView.Adapter<V2>, A2 : ComposableAdapter.ViewTypeProvider {
+                where A1 : RecyclerView.Adapter<V1>,
+                      A1 : ComposableAdapter.ViewTypeProvider,
+                      A2 : RecyclerView.Adapter<V2>,
+                      A2 : ComposableAdapter.ViewTypeProvider {
             }
             """.trimIndent()
         wrappingRuleAssertThat(code).hasNoLintViolations()
@@ -1911,5 +1913,59 @@ internal class WrappingRuleTest {
                 }
             """.trimIndent()
         wrappingRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `Given a function with return type and WHERE and unexpected newline before comma between type constraints `() {
+        val code =
+            """
+            fun <T> copyWhenGreater(list: List<T>, threshold: T): List<String>
+                where T : CharSequence
+                , T : Comparable<T> {
+                return list.filter { it > threshold }.map { it.toString() }
+            }
+
+            fun <T> copyWhenGreater(list: List<T>, threshold: T): List<String>
+                where T : CharSequence /* Some comment */
+                , T : Comparable<T> {
+                return list.filter { it > threshold }.map { it.toString() }
+            }
+
+            fun <T> copyWhenGreater(list: List<T>, threshold: T): List<String>
+                where T : CharSequence // Some comment
+                , T : Comparable<T> {
+                return list.filter { it > threshold }.map { it.toString() }
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            fun <T> copyWhenGreater(list: List<T>, threshold: T): List<String>
+                where T : CharSequence,
+                      T : Comparable<T> {
+                return list.filter { it > threshold }.map { it.toString() }
+            }
+
+            fun <T> copyWhenGreater(list: List<T>, threshold: T): List<String>
+                where T : CharSequence /* Some comment */,
+                      T : Comparable<T> {
+                return list.filter { it > threshold }.map { it.toString() }
+            }
+
+            fun <T> copyWhenGreater(list: List<T>, threshold: T): List<String>
+                where T : CharSequence, // Some comment
+                      T : Comparable<T> {
+                return list.filter { it > threshold }.map { it.toString() }
+            }
+            """.trimIndent()
+        wrappingRuleAssertThat(code)
+            .addAdditionalRuleProvider { IndentationRule() }
+            .hasLintViolations(
+                LintViolation(3, 5, "No whitespace was expected before ','"),
+                LintViolation(3, 7, "A newline was expected before 'T : Comparable<T>'"),
+                LintViolation(9, 5, "No whitespace was expected before ','"),
+                LintViolation(9, 7, "A newline was expected before 'T : Comparable<T>'"),
+                LintViolation(15, 5, "No whitespace was expected before ','"),
+                LintViolation(15, 7, "A newline was expected before 'T : Comparable<T>'"),
+            ).isFormattedAs(formattedCode)
     }
 }


### PR DESCRIPTION
## Description

Move comma in a multiline constraint type list after the constraint type

Incorrect usages:
```
fun <T> copyWhenGreater(list: List<T>, threshold: T): List<String>
    where T : CharSequence
    , T : Comparable<T> {
    return list.filter { it > threshold }.map { it.toString() }
}

fun <T> copyWhenGreater(list: List<T>, threshold: T): List<String>
    where T : CharSequence /* Some comment */
    , T : Comparable<T> {
    return list.filter { it > threshold }.map { it.toString() }
}

fun <T> copyWhenGreater(list: List<T>, threshold: T): List<String>
    where T : CharSequence // Some comment
    , T : Comparable<T> {
    return list.filter { it > threshold }.map { it.toString() }
}
```

Correct usages:
```
fun <T> copyWhenGreater(list: List<T>, threshold: T): List<String>
    where T : CharSequence,
          T : Comparable<T> {
    return list.filter { it > threshold }.map { it.toString() }
}

fun <T> copyWhenGreater(list: List<T>, threshold: T): List<String>
    where T : CharSequence /* Some comment */,
          T : Comparable<T> {
    return list.filter { it > threshold }.map { it.toString() }
}

fun <T> copyWhenGreater(list: List<T>, threshold: T): List<String>
    where T : CharSequence, // Some comment
          T : Comparable<T> {
    return list.filter { it > threshold }.map { it.toString() }
}
```

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://ktlint.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/ktlint/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/ktlint/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/ktlint/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
