### PR TITLE
Fix references to `io.github.ktlint.core` in `ktlint-ruleset-template`

### DIFF
--- a/ktlint-ruleset-template/build.gradle.kts
+++ b/ktlint-ruleset-template/build.gradle.kts
@@ -30,27 +30,27 @@ val ktlint: Configuration by configurations.creating
 // External users who copy this template should remove this block and ensure mavenCentral() is in their repositories.
 configurations.all {
     resolutionStrategy.dependencySubstitution {
-        substitute(module("io.github.ktlint:ktlint-cli")).using(project(":ktlint-cli"))
-        substitute(module("io.github.ktlint:ktlint-cli-ruleset-core")).using(project(":ktlint-cli-ruleset-core"))
-        substitute(module("io.github.ktlint:ktlint-rule-engine-core")).using(project(":ktlint-rule-engine-core"))
-        substitute(module("io.github.ktlint:ktlint-test")).using(project(":ktlint-test"))
+        substitute(module("io.github.ktlint.core:ktlint-cli")).using(project(":ktlint-cli"))
+        substitute(module("io.github.ktlint.core:ktlint-cli-ruleset-core")).using(project(":ktlint-cli-ruleset-core"))
+        substitute(module("io.github.ktlint.core:ktlint-rule-engine-core")).using(project(":ktlint-rule-engine-core"))
+        substitute(module("io.github.ktlint.core:ktlint-test")).using(project(":ktlint-test"))
     }
 }
 
 // Update the version numbers of dependencies below to the most recent stable versions
 dependencies {
     // Remove when the Gradle task 'ktlintCheck' is not to be added to the project
-    ktlint("io.github.ktlint:ktlint-cli:2.0.0-SNAPSHOT")
+    ktlint("io.github.ktlint.core:ktlint-cli:2.0.0-SNAPSHOT")
 
-    implementation("io.github.ktlint:ktlint-cli-ruleset-core:2.0.0-SNAPSHOT")
-    implementation("io.github.ktlint:ktlint-rule-engine-core:2.0.0-SNAPSHOT")
+    implementation("io.github.ktlint.core:ktlint-cli-ruleset-core:2.0.0-SNAPSHOT")
+    implementation("io.github.ktlint.core:ktlint-rule-engine-core:2.0.0-SNAPSHOT")
 
     testImplementation("org.junit.jupiter:junit-jupiter:6.1.3")
     // Since Gradle 8 the platform launcher needs explicitly be defined as runtime dependency to avoid classpath problems
     // https://docs.gradle.org/8.12/userguide/upgrading_version_8.html#test_framework_implementation_dependencies
     testImplementation("org.junit.platform:junit-platform-launcher:6.1.3")
     testImplementation("org.slf4j:slf4j-simple:2.0.18")
-    testImplementation("io.github.ktlint:ktlint-test:2.0.0-SNAPSHOT")
+    testImplementation("io.github.ktlint.core:ktlint-test:2.0.0-SNAPSHOT")
 }
 
 tasks.test {


### PR DESCRIPTION
## Description

Fix references to `io.github.ktlint.core` in `ktlint-ruleset-template`. This should resolve warning below in the [DependencyDashboard](https://github.com/ktlint/ktlint/issues/2035):
```
Renovate failed to look up the following dependencies: Failed to look up maven package io.github.ktlint:ktlint-cli: no-result, Failed to look up maven package io.github.ktlint:ktlint-cli-ruleset-core: no-result, Failed to look up maven package io.github.ktlint:ktlint-rule-engine-core: no-result, Failed to look up maven package io.github.ktlint:ktlint-test: no-result.

Files affected: ktlint-ruleset-template/build.gradle.kts
```

The `ktlint-ruleset-template` module uses direct dependencies on `io.github.ktlint.core` instead of reusing the `lib.versions.toml` of the project as this module is intended to be copied as base of a new ktlint ruleset project.

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [ ] Tests are added
- [ ] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://ktlint.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/ktlint/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/ktlint/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/ktlint/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
