### PR TITLE
Fix alignment of same-line WHERE clause in class declarations

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/io/github/ktlint/core/ruleset/standard/rules/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/io/github/ktlint/core/ruleset/standard/rules/IndentationRule.kt
@@ -710,6 +710,14 @@ public class IndentationRule :
                     startIndentContext(
                         fromAstNode = where.getPrecedingLeadingCommentsAndWhitespaces(),
                         toAstNode = typeConstraintList.lastChildLeafOrSelf,
+                        childIndent =
+                            if (where.prevLeaf?.isWhiteSpaceWithNewline == true) {
+                                indentConfig.indent
+                            } else {
+                                " ".repeat(
+                                    maxOf(0, where.column - 1 - node.indentWithoutNewlinePrefix.length),
+                                )
+                            },
                     ).prevCodeLeaf()
             }
 

--- a/ktlint-ruleset-standard/src/test/kotlin/io/github/ktlint/core/ruleset/standard/rules/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/io/github/ktlint/core/ruleset/standard/rules/IndentationRuleTest.kt
@@ -2825,6 +2825,42 @@ internal class IndentationRuleTest {
     }
 
     @Nested
+    inner class `Issue 3380 - Given a class declaration using the WHERE keyword on the same line` {
+        @Test
+        fun `Issue 3380 - Given a class declaration with WHERE on same line`() {
+            val code =
+                """
+                class Container<T> where T : Comparable<T>,
+                                         T : java.io.Serializable {
+                    fun body() {}
+                }
+                """.trimIndent()
+            indentationRuleAssertThat(code).hasNoLintViolations()
+        }
+
+        @Test
+        fun `Issue 3380 - Given a misaligned class declaration with WHERE on same line`() {
+            val code =
+                """
+                class Container<T> where T : Comparable<T>,
+                          T : java.io.Serializable {
+                    fun body() {}
+                }
+                """.trimIndent()
+            val formattedCode =
+                """
+                class Container<T> where T : Comparable<T>,
+                                         T : java.io.Serializable {
+                    fun body() {}
+                }
+                """.trimIndent()
+            indentationRuleAssertThat(code)
+                .hasLintViolation(2, 1, "Unexpected indentation (10) (should be 25)")
+                .isFormattedAs(formattedCode)
+        }
+    }
+
+    @Nested
     inner class `Issue 3362 - Given the WHERE keyword and tab indentation` {
         @Test
         fun `Given a well formed WHERE with multiple type constraints`() {


### PR DESCRIPTION
## Description

`standard:indent` only computed the correct alignment width for a same-line `WHERE` clause in `visitFun` (function declarations). `visitClass` had no equivalent branch and always fell back to the default indent (4 spaces), regardless of where the `where` keyword was positioned.

As a result, a correctly aligned same-line `where` clause on a class declaration:

```kotlin
class Container<T> where T : Comparable<T>,
                         T : java.io.Serializable {
    fun body() {}
}
```

was rejected (`Unexpected indentation (25) (should be 10)`) and reformatted to a fixed 4-space-multiple indent, breaking alignment with the first type constraint:

```kotlin
class Container<T> where T : Comparable<T>,
          T : java.io.Serializable {
    fun body() {}
}
```

The fix mirrors the existing `visitFun` logic: when `where` is on the same line as the declaration, `childIndent` is computed from the column of the `where` keyword instead of falling back to the default indent.

Fixes #3380

## Checklist

- [x] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [x] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [x] Tests are added
- [x] KtLint format has been applied on source code itself and violations are fixed
- [x] PR title is short and clear (it is used as description in the release changelog)
- [x] PR description added (background information)

[Documentation](https://ktlint.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/ktlint/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/ktlint/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/ktlint/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master

No documentation changes needed — this fixes a bug in existing behavior, it does not change any documented rule configuration or option.
