### PR TITLE
Wrap `where` keyword in a multiline type constraint list

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/io/github/ktlint/core/ruleset/standard/rules/WrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/io/github/ktlint/core/ruleset/standard/rules/WrappingRule.kt
@@ -43,6 +43,7 @@ import io.github.ktlint.core.rule.engine.core.api.ElementType.VALUE_ARGUMENT_LIS
 import io.github.ktlint.core.rule.engine.core.api.ElementType.VALUE_PARAMETER
 import io.github.ktlint.core.rule.engine.core.api.ElementType.VALUE_PARAMETER_LIST
 import io.github.ktlint.core.rule.engine.core.api.ElementType.WHEN_ENTRY
+import io.github.ktlint.core.rule.engine.core.api.ElementType.WHERE_KEYWORD
 import io.github.ktlint.core.rule.engine.core.api.ElementType.WHITE_SPACE
 import io.github.ktlint.core.rule.engine.core.api.IndentConfig
 import io.github.ktlint.core.rule.engine.core.api.IndentConfig.Companion.DEFAULT_INDENT_CONFIG
@@ -136,7 +137,7 @@ public class WrappingRule :
             SUPER_TYPE_LIST -> rearrangeSuperTypeList(node, emit)
             VALUE_PARAMETER_LIST, VALUE_ARGUMENT_LIST -> rearrangeValueList(node, emit)
             TYPE_ARGUMENT_LIST, TYPE_PARAMETER_LIST -> rearrangeTypeArgumentList(node, emit)
-            TYPE_CONSTRAINT_LIST -> rearrangeTypeConstraintList(node, emit)
+            WHERE_KEYWORD -> rearrangeTypeConstraintList(node, emit)
             ARROW -> rearrangeArrow(node, emit)
             WHITE_SPACE -> line += node.text.count { it == '\n' }
             CLOSING_QUOTE -> rearrangeClosingQuote(node, emit)
@@ -437,17 +438,30 @@ public class WrappingRule :
         node: ASTNode,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> AutocorrectDecision,
     ) {
-        require(node.elementType == TYPE_CONSTRAINT_LIST)
+        require(node.elementType == WHERE_KEYWORD)
 
-        if (node.textContains('\n')) {
+        if (hasNewLineInClosedRange(node, node.nextSibling { it.elementType == TYPE_CONSTRAINT_LIST } ?: node)) {
+            // Indent where keyword
+            node
+                .prevSibling { !it.isPartOfComment }
+                .let { prevSibling ->
+                    if (prevSibling.isWhiteSpaceWithoutNewline) {
+                        emit(node.startOffset, "A newline was expected before 'where'", true)
+                            .ifAutocorrectAllowed {
+                                node.upsertWhitespaceBeforeMe(indentConfig.siblingIndentOf(node))
+                            }
+                    }
+                }
+
             // Each type projection must be preceded with a whitespace containing a newline
             node
-                .children
-                .forEach { child ->
+                .nextSibling { it.elementType == TYPE_CONSTRAINT_LIST }
+                ?.children
+                ?.forEach { child ->
                     when (child.elementType) {
                         COMMA -> {
                             child
-                                .prevSibling // { !it.isPartOfComment }
+                                .prevSibling
                                 ?.takeIf { it.isWhiteSpaceWithNewline }
                                 ?.let { whitespaceWithNewline ->
                                     emit(child.startOffset, "No whitespace was expected before '${child.text}'", true)

--- a/ktlint-ruleset-standard/src/test/kotlin/io/github/ktlint/core/ruleset/standard/rules/WrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/io/github/ktlint/core/ruleset/standard/rules/WrappingRuleTest.kt
@@ -1968,4 +1968,86 @@ internal class WrappingRuleTest {
                 LintViolation(15, 7, "A newline was expected before 'T : Comparable<T>'"),
             ).isFormattedAs(formattedCode)
     }
+
+    @Test
+    fun `Given a function with a multiline WHERE`() {
+        val code =
+            """
+            fun <T> copy(list: List<T>): List<String> where T : CharSequence,
+                T : Comparable<T> {
+                return list.map { it.toString() }
+            }
+
+            fun <T> copy(list: List<T>): List<String> where T : CharSequence
+                , T : Comparable<T> {
+                return list.map { it.toString() }
+            }
+
+            fun <T> copy(list: List<T>): List<String> where T : CharSequence /* Some comment */
+                , T : Comparable<T> {
+                return list.map { it.toString() }
+            }
+
+            fun <T> copy(list: List<T>): List<String> where T : CharSequence // Some comment
+                , T : Comparable<T> {
+                return list.map { it.toString() }
+            }
+            """.trimIndent()
+        val formattedCode =
+            """
+            fun <T> copy(list: List<T>): List<String>
+                where T : CharSequence,
+                      T : Comparable<T> {
+                return list.map { it.toString() }
+            }
+
+            fun <T> copy(list: List<T>): List<String>
+                where T : CharSequence,
+                      T : Comparable<T> {
+                return list.map { it.toString() }
+            }
+
+            fun <T> copy(list: List<T>): List<String>
+                where T : CharSequence /* Some comment */,
+                      T : Comparable<T> {
+                return list.map { it.toString() }
+            }
+
+            fun <T> copy(list: List<T>): List<String>
+                where T : CharSequence, // Some comment
+                      T : Comparable<T> {
+                return list.map { it.toString() }
+            }
+            """.trimIndent()
+        wrappingRuleAssertThat(code)
+            .addAdditionalRuleProvider { IndentationRule() }
+            .hasLintViolations(
+                LintViolation(1, 43, "A newline was expected before 'where'"),
+                LintViolation(6, 43, "A newline was expected before 'where'"),
+                LintViolation(7, 5, "No whitespace was expected before ','"),
+                LintViolation(7, 7, "A newline was expected before 'T : Comparable<T>'"),
+                LintViolation(11, 43, "A newline was expected before 'where'"),
+                LintViolation(12, 5, "No whitespace was expected before ','"),
+                LintViolation(12, 7, "A newline was expected before 'T : Comparable<T>'"),
+                LintViolation(16, 43, "A newline was expected before 'where'"),
+                LintViolation(17, 5, "No whitespace was expected before ','"),
+                LintViolation(17, 7, "A newline was expected before 'T : Comparable<T>'"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
+    fun `Given a function with a single line WHERE then do not reformat`() {
+        val code =
+            """
+            fun <T> copyWhenGreater(list: List<T>, threshold: T): List<String> where T : CharSequence, T : Comparable<T> {
+                return list.filter { it > threshold }.map { it.toString() }
+            }
+
+            fun <T> copyWhenGreater(list: List<T>, threshold: T): List<String>
+                where T : CharSequence, T : Comparable<T> {
+                return list.filter { it > threshold }.map { it.toString() }
+            }
+            """.trimIndent()
+        wrappingRuleAssertThat(code).hasNoLintViolations()
+    }
 }


### PR DESCRIPTION
## Description

Wrap `where` keyword in a multiline type constraint list

Before:
```
fun <T> copy(list: List<T>): List<String> where T : CharSequence,
    T : Comparable<T> {
    return list.map { it.toString() }
}
```

After format:
```
fun <T> copy(list: List<T>): List<String>
    where T : CharSequence,
          T : Comparable<T> =
    list.map { it.toString() }
```

## Checklist

Before submitting the PR, please check following (checks which are not relevant may be ignored):
- [X] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [ ] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [X] Tests are added
- [X] KtLint format has been applied on source code itself and violations are fixed
- [X] PR title is short and clear (it is used as description in the release changelog)
- [X] PR description added (background information)

[Documentation](https://ktlint.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/ktlint/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/ktlint/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/ktlint/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master 
