### PR TITLE
Check type-parameter-list-spacing for generic extension properties

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/io/github/ktlint/core/ruleset/standard/rules/TypeParameterListSpacingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/io/github/ktlint/core/ruleset/standard/rules/TypeParameterListSpacingRule.kt
@@ -9,6 +9,7 @@ import io.github.ktlint.core.rule.engine.core.api.ElementType.FUN
 import io.github.ktlint.core.rule.engine.core.api.ElementType.GT
 import io.github.ktlint.core.rule.engine.core.api.ElementType.LT
 import io.github.ktlint.core.rule.engine.core.api.ElementType.PRIMARY_CONSTRUCTOR
+import io.github.ktlint.core.rule.engine.core.api.ElementType.PROPERTY
 import io.github.ktlint.core.rule.engine.core.api.ElementType.TYPEALIAS
 import io.github.ktlint.core.rule.engine.core.api.ElementType.TYPE_PARAMETER_LIST
 import io.github.ktlint.core.rule.engine.core.api.IndentConfig
@@ -70,7 +71,7 @@ public class TypeParameterListSpacingRule :
         when (node.parent?.elementType) {
             CLASS -> visitClassDeclaration(node, emit)
             TYPEALIAS -> visitTypeAliasDeclaration(node, emit)
-            FUN -> visitFunctionDeclaration(node, emit)
+            FUN, PROPERTY -> visitFunctionOrPropertyDeclaration(node, emit)
         }
         visitInsideTypeParameterList(node, emit)
     }
@@ -156,12 +157,13 @@ public class TypeParameterListSpacingRule :
             ?.let { singleSpaceExpected(it, emit) }
     }
 
-    private fun visitFunctionDeclaration(
+    private fun visitFunctionOrPropertyDeclaration(
         node: ASTNode,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> AutocorrectDecision,
     ) {
-        // Single space expected before type parameter list of function
+        // Single space expected before type parameter list of function or property
         //    fun<T> foo(...)
+        //    val<T> List<T>.foo: T
         node
             .prevLeaf
             ?.let { prevLeaf ->
@@ -172,9 +174,10 @@ public class TypeParameterListSpacingRule :
                 }
             }
 
-        // Single space expected after type parameter list of function
+        // Single space expected after type parameter list of function or property
         //   fun <T>foo(...)
         //   fun <T>List<T>foo(...)
+        //   val <T>List<T>.foo: T
         node
             .lastChildNode
             .nextLeaf

--- a/ktlint-ruleset-standard/src/test/kotlin/io/github/ktlint/core/ruleset/standard/rules/TypeParameterListSpacingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/io/github/ktlint/core/ruleset/standard/rules/TypeParameterListSpacingRuleTest.kt
@@ -112,6 +112,25 @@ class TypeParameterListSpacingRuleTest {
     }
 
     @Test
+    fun `Given a generic extension property with a type parameter list not preceded or followed by a space then add the missing space`() {
+        val code =
+            """
+            val<T>List<T>.head: T
+                get() = this[0]
+            """.trimIndent()
+        val formattedCode =
+            """
+            val <T> List<T>.head: T
+                get() = this[0]
+            """.trimIndent()
+        typeParameterListSpacingRuleAssertThat(code)
+            .hasLintViolations(
+                LintViolation(1, 4, "Expected a single space"),
+                LintViolation(1, 7, "Expected a single space"),
+            ).isFormattedAs(formattedCode)
+    }
+
+    @Test
     fun `Given a class or interface definition with a type parameter list followed by multiple spaces then the redundant spaces are removed`() {
         val code =
             """


### PR DESCRIPTION
## Description

`standard:type-parameter-list-spacing` dispatches its spacing checks based on the parent element type of the type parameter list, but only had branches for `CLASS`, `TYPEALIAS`, and `FUN`. There was no branch for `PROPERTY`, so spacing around the type parameter list of a generic extension property was never checked:

```kotlin
val<T>List<T>.head: T
    get() = this[0]
```

reported no violations, even though the equivalent function extension (`fun<T>List<T>.head() = ...`) was already correctly flagged.

The fix reuses the existing function-declaration handling for `PROPERTY` as well (renamed to `visitFunctionOrPropertyDeclaration` since the logic — single space before and after the type parameter list — applies identically to both).

Fixes #3383

## Checklist

- [x] Commit message are well written. In addition to a short title, the commit message also explain why a change is made.
- [x] At least one commit message contains a reference `Closes #<xxx>` or `Fixes #<xxx>` (replace`<xxx>` with issue number)
- [x] Tests are added
- [x] KtLint format has been applied on source code itself and violations are fixed
- [x] PR title is short and clear (it is used as description in the release changelog)
- [x] PR description added (background information)

[Documentation](https://ktlint.github.io/ktlint/) is updated. See [difference between snapshot and release documentation](https://github.com/ktlint/ktlint/tree/master/documentation)
- [ ] [Snapshot documentation](https://github.com/ktlint/ktlint/tree/master/documentation/snapshot) in case documentation is to be released together with a code change
- [ ] [Release documentation](https://github.com/ktlint/ktlint/tree/master/documentation/release-latest) in case documentation is related to a released version of ktlint and has to be published as soon as the change is merged to master

No documentation changes needed — this fixes a bug in existing behavior, it does not change any documented rule configuration or option.
